### PR TITLE
Converting to typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
     node: true,
   },
   rules: {},
+  ignorePatterns: ['transforms/**/*.js'],
   overrides: [
     {
       files: ['__tests__/**/*.js'],

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /node_modules
 /.eslintcache
-/transforms/**/*.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /.eslintcache
+/transforms/**/*.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,13 @@
+.github/
+.eslintignore
+.eslintcache
+.eslintrc.js
+np.github/workflows/ci.yml
+.prettierrc
+@types/codemod-cli.d.ts
+CHANGELOG.md
+RELEASE.md
+**/__testfixtures__/**
+**/transforms/**/test.js
+**/*.ts
+tsconfig.json

--- a/@types/codemod-cli.d.ts
+++ b/@types/codemod-cli.d.ts
@@ -1,0 +1,1 @@
+declare module 'codemod-cli';

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ node ./bin/cli.js <TRANSFORM NAME> path/of/files/ or/some**/*glob.js
 ## Transforms
 
 <!--TRANSFORMS_START-->
+* [add-vitest-imports](transforms/add-vitest-imports/README.md)
 <!--TRANSFORMS_END-->
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "yarn build && yarn lint && codemod-cli test",
     "test:coverage": "yarn build && codemod-cli test --coverage",
     "update-docs": "codemod-cli update-docs",
-    "prepublish": "yarn build",
+    "prepublishOnly": "yarn build",
     "postinstall": "yarn build",
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint --cache .",
-    "test": "yarn build && codemod-cli test",
+    "test": "yarn build && yarn lint && codemod-cli test",
     "test:coverage": "yarn build && codemod-cli test --coverage",
     "update-docs": "codemod-cli update-docs",
     "prepublish": "yarn build",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,16 @@
   },
   "bin": "./bin/cli.js",
   "scripts": {
+    "build": "tsc",
     "lint": "eslint --cache .",
-    "test": "codemod-cli test",
-    "test:coverage": "codemod-cli test --coverage",
+    "test": "yarn build && codemod-cli test",
+    "test:coverage": "yarn build && codemod-cli test --coverage",
     "update-docs": "codemod-cli update-docs",
+    "prepublish": "yarn build",
+    "postinstall": "yarn build",
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls"
   },
+  "license": "MIT",
   "jest": {
     "testEnvironment": "node"
   },
@@ -25,6 +29,7 @@
     "jscodeshift-add-imports": "^1.0.10"
   },
   "devDependencies": {
+    "@types/jscodeshift": "^0.11.3",
     "coveralls": "^3.1.0",
     "eslint": "^8.6.0",
     "eslint-config-prettier": "^8.3.0",
@@ -33,7 +38,8 @@
     "jest": "^26.6.3",
     "prettier": "^2.5.1",
     "release-it": "^14.2.1",
-    "release-it-lerna-changelog": "^3.1.0"
+    "release-it-lerna-changelog": "^3.1.0",
+    "typescript": "^4.5.4"
   },
   "engines": {
     "node": "10.* || 12.* || >= 14"

--- a/transforms/add-vitest-imports/README.md
+++ b/transforms/add-vitest-imports/README.md
@@ -20,7 +20,155 @@ node ./bin/cli.js add-vitest-imports path/of/files/ or/some**/*glob.js
 ## Input / Output
 
 <!--FIXTURES_TOC_START-->
+* [multiple-imports](#multiple-imports)
+* [multiple-jest-apis](#multiple-jest-apis)
+* [multiple-nested-jest-apis](#multiple-nested-jest-apis)
+* [no-apis](#no-apis)
+* [root-test-only](#root-test-only)
 <!--FIXTURES_TOC_END-->
 
 <!--FIXTURES_CONTENT_START-->
+---
+<a id="multiple-imports">**multiple-imports**</a>
+
+**Input** (<small>[multiple-imports.input.js](transforms/add-vitest-imports/__testfixtures__/multiple-imports.input.js)</small>):
+```js
+import { isCity } from './cities';
+
+test('city database has Vienna', () => {
+  expect(isCity('Vienna')).toBeTruthy();
+});
+
+```
+
+**Output** (<small>[multiple-imports.output.js](transforms/add-vitest-imports/__testfixtures__/multiple-imports.output.js)</small>):
+```js
+import { isCity } from './cities';
+
+import { test, expect } from 'vitest';
+
+test('city database has Vienna', () => {
+  expect(isCity('Vienna')).toBeTruthy();
+});
+
+```
+---
+<a id="multiple-jest-apis">**multiple-jest-apis**</a>
+
+**Input** (<small>[multiple-jest-apis.input.js](transforms/add-vitest-imports/__testfixtures__/multiple-jest-apis.input.js)</small>):
+```js
+beforeEach(() => {
+  initializeCityDatabase();
+});
+
+afterEach(() => {
+  clearCityDatabase();
+});
+
+test('city database has Vienna', () => {
+  expect(isCity('Vienna')).toBeTruthy();
+});
+
+test('city database has San Juan', () => {
+  expect(isCity('San Juan')).toBeTruthy();
+});
+
+```
+
+**Output** (<small>[multiple-jest-apis.output.js](transforms/add-vitest-imports/__testfixtures__/multiple-jest-apis.output.js)</small>):
+```js
+import { beforeEach, afterEach, test, expect } from 'vitest';
+beforeEach(() => {
+  initializeCityDatabase();
+});
+
+afterEach(() => {
+  clearCityDatabase();
+});
+
+test('city database has Vienna', () => {
+  expect(isCity('Vienna')).toBeTruthy();
+});
+
+test('city database has San Juan', () => {
+  expect(isCity('San Juan')).toBeTruthy();
+});
+
+```
+---
+<a id="multiple-nested-jest-apis">**multiple-nested-jest-apis**</a>
+
+**Input** (<small>[multiple-nested-jest-apis.input.js](transforms/add-vitest-imports/__testfixtures__/multiple-nested-jest-apis.input.js)</small>):
+```js
+describe('foo', () => {
+  beforeEach(() => {
+    initializeCityDatabase();
+  });
+
+  afterEach(() => {
+    disposeCityDatabase();
+  });
+
+  it('can describe a test', () => {
+    expect(isCity('San Francisco')).toBeTruthy();
+  });
+});
+
+```
+
+**Output** (<small>[multiple-nested-jest-apis.output.js](transforms/add-vitest-imports/__testfixtures__/multiple-nested-jest-apis.output.js)</small>):
+```js
+import { beforeEach, afterEach, it, expect, describe } from 'vitest';
+describe('foo', () => {
+  beforeEach(() => {
+    initializeCityDatabase();
+  });
+
+  afterEach(() => {
+    disposeCityDatabase();
+  });
+
+  it('can describe a test', () => {
+    expect(isCity('San Francisco')).toBeTruthy();
+  });
+});
+
+```
+---
+<a id="no-apis">**no-apis**</a>
+
+**Input** (<small>[no-apis.input.js](transforms/add-vitest-imports/__testfixtures__/no-apis.input.js)</small>):
+```js
+function noTests() {
+  console.log('nothing');
+}
+
+```
+
+**Output** (<small>[no-apis.output.js](transforms/add-vitest-imports/__testfixtures__/no-apis.output.js)</small>):
+```js
+function noTests() {
+  console.log('nothing');
+}
+
+```
+---
+<a id="root-test-only">**root-test-only**</a>
+
+**Input** (<small>[root-test-only.input.js](transforms/add-vitest-imports/__testfixtures__/root-test-only.input.js)</small>):
+```js
+test('city database has Vienna', () => {
+  expect(isCity('Vienna')).toBeTruthy();
+});
+
+```
+
+**Output** (<small>[root-test-only.output.js](transforms/add-vitest-imports/__testfixtures__/root-test-only.output.js)</small>):
+```js
+import { test, expect } from 'vitest';
+test('city database has Vienna', () => {
+  expect(isCity('Vienna')).toBeTruthy();
+});
+
+```
 <!--FIXTURES_CONTENT_END-->

--- a/transforms/add-vitest-imports/index.js
+++ b/transforms/add-vitest-imports/index.js
@@ -1,0 +1,30 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var codemod_cli_1 = __importDefault(require("codemod-cli"));
+var jscodeshift_add_imports_1 = __importDefault(require("jscodeshift-add-imports"));
+var getParser = codemod_cli_1.default.jscodeshift.getParser;
+function transformer(file, api) {
+    var j = getParser(api);
+    var root = j(file.source);
+    var apis = [];
+    for (var _i = 0, _a = ['beforeEach', 'afterEach', 'test', 'it', 'expect', 'describe']; _i < _a.length; _i++) {
+        var name = _a[_i];
+        var calls = root.find(j.CallExpression, { callee: { name: name } });
+        if (calls.length > 0) {
+            apis.push(j.importSpecifier(j.identifier(name), j.identifier(name)));
+        }
+    }
+    if (apis.length) {
+        (0, jscodeshift_add_imports_1.default)(root, j.importDeclaration(apis, j.stringLiteral('vitest')));
+    }
+    return root.toSource({
+        quote: 'single',
+        wrapColumn: 100,
+        trailingComma: true,
+    });
+}
+exports.default = transformer;
+module.exports.type = 'js';

--- a/transforms/add-vitest-imports/index.ts
+++ b/transforms/add-vitest-imports/index.ts
@@ -1,7 +1,10 @@
-const { getParser } = require('codemod-cli').jscodeshift;
-const addImports = require('jscodeshift-add-imports');
+import { FileInfo, API } from 'jscodeshift';
+import codemodCli from 'codemod-cli';
+import addImports from 'jscodeshift-add-imports';
 
-module.exports = function transformer(file, api) {
+const { getParser } = codemodCli.jscodeshift;
+
+export default function transformer(file: FileInfo, api: API) {
   const j = getParser(api);
   const root = j(file.source);
   const apis = [];
@@ -23,6 +26,6 @@ module.exports = function transformer(file, api) {
     wrapColumn: 100,
     trailingComma: true,
   });
-};
+}
 
 module.exports.type = 'js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "skipLibCheck": true,
+    "removeComments": false,
+    "stripInternal": true,
+    "alwaysStrict": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -717,6 +717,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^27.4.2":
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.4.2.tgz#96536ebd34da6392c2b7c7737d693885b5dd44a5"
+  integrity sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -961,6 +972,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jscodeshift@^0.11.3":
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/@types/jscodeshift/-/jscodeshift-0.11.3.tgz#8dcab24ced39dcab1c8ff3461b3d171aafee3d48"
+  integrity sha512-pM0JD9kWVDH9DQp5Y6td16924V3MwZHei8P3cTeuFhXpzpk0K+iWraBZz8wF61QkFs9fZeAQNX0q8SG0+TFm2w==
+  dependencies:
+    ast-types "^0.14.1"
+    recast "^0.20.3"
+
 "@types/keyv@*":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.3.tgz#1c9aae32872ec1f20dcdaee89a9f3ba88f465e41"
@@ -1021,6 +1040,13 @@
   version "15.0.14"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
   integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^16.0.0":
+  version "16.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
+  integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -1226,7 +1252,7 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-ast-types@0.14.2:
+ast-types@0.14.2, ast-types@^0.14.1:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
   integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
@@ -1457,6 +1483,13 @@ browserslist@^4.17.5:
     escalade "^3.1.1"
     node-releases "^2.0.1"
     picocolors "^1.0.0"
+
+bs-logger@0.x:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
 
 bser@2.1.1:
   version "2.1.1"
@@ -2578,7 +2611,7 @@ fast-glob@^3.1.1, fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -3925,6 +3958,18 @@ jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
+jest-util@^27.0.0:
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.4.2.tgz#ed95b05b1adfd761e2cda47e0144c6a58e05a621"
+  integrity sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==
+  dependencies:
+    "@jest/types" "^27.4.2"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.4"
+    picomatch "^2.2.3"
+
 jest-validate@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-26.6.2.tgz#23d380971587150467342911c3d7b4ac57ab20ec"
@@ -4129,7 +4174,7 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^2.1.2:
+json5@2.x, json5@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
@@ -4265,6 +4310,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.memoize@4.x:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -4331,6 +4381,11 @@ make-dir@^3.0.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-error@1.x:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 make-fetch-happen@^7.1.1:
   version "7.1.1"
@@ -5599,7 +5654,7 @@ semver-diff@^3.1.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@7.3.5, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
+semver@7.3.5, semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -6142,6 +6197,20 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
+ts-jest@^27.1.2:
+  version "27.1.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.2.tgz#5991d6eb3fd8e1a8d4b8f6de3ec0a3cc567f3151"
+  integrity sha512-eSOiJOWq6Hhs6Khzk5wKC5sgWIXgXqOCiIl1+3lfnearu58Hj4QpE5tUhQcA3xtZrELbcvAGCsd6HB8OsaVaTA==
+  dependencies:
+    bs-logger "0.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^27.0.0"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
+
 tslib@^2.0.1, tslib@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
@@ -6209,6 +6278,11 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
+
+typescript@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -6585,7 +6659,7 @@ yaml@1.10.2, yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargs-parser@20.2.9, yargs-parser@^20.2.2:
+yargs-parser@20.2.9, yargs-parser@20.x, yargs-parser@^20.2.2:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==


### PR DESCRIPTION
Includes refining publishing via `.npmignore`, and regenerating docs using `yarn update-docs`.