### PR TITLE
Removing postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "test:coverage": "yarn build && codemod-cli test --coverage",
     "update-docs": "codemod-cli update-docs",
     "prepublishOnly": "yarn build",
-    "postinstall": "yarn build",
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls"
   },
   "license": "MIT",


### PR DESCRIPTION
Adding a `postinstall` script causes this package to fail when installing or using `npx`. It's unnecessary anyway, because we build on `prepublishOnly` and publish `.js` files.